### PR TITLE
correctly get error string when ks_asm fails

### DIFF
--- a/keystone_gem/lib/keystone_engine.rb
+++ b/keystone_gem/lib/keystone_engine.rb
@@ -10,7 +10,7 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -61,12 +61,12 @@ module KeystoneEngine extend FFI::Library
         def asm(instructions, address=0)
             inst = FFI::MemoryPointer.from_string(instructions)
             bytes = StringPtr.new
-            size = IntPtr.new 
+            size = IntPtr.new
             count = IntPtr.new
             err = KeystoneEngine::ks_asm(ks, inst, address, bytes, size, count)
 
             if err != KS_ERR_OK
-                raise KsError, KeystoneEngine::ks_strerror(err).read_string
+                raise KsError, KeystoneEngine::ks_strerror(KeystoneEngine::ks_errno(ks)).read_string
             end
 
             return [bytes[:value].read_string(size[:value]), count[:value]]


### PR DESCRIPTION
ks_asm() returns -1 on any failure, to get the real error code for use with ks_strerror() we need to invoke ks_errno() first.